### PR TITLE
Add new cities.txt and changes to answers.txt

### DIFF
--- a/Lists/Students/0000001010011010/cities.txt
+++ b/Lists/Students/0000001010011010/cities.txt
@@ -1,0 +1,3 @@
+Barcelona
+Instanbul
+Espoo

--- a/answers.txt
+++ b/answers.txt
@@ -1,6 +1,6 @@
-Number of students who modified this file: 110 students
+Number of students who modified this file: 115 students
 
-Name of the last student who modified this file: Omar Abdelfattah
+Name of the last student who modified this file: Teemu Peltonen
 -----------------------------------------------------
 [Template]
 Student ID:1234567
@@ -1264,3 +1264,14 @@ Your favorite sport: Cycling
 
 Question 3.
 Your favorite food: Shrimps
+-----------------------------------------------------
+Student ID:0000001010011010
+Name: Teemu Peltonen
+Question 1.
+Your favorite color: Robin egg blue
+
+Question 2.
+Your favorite sport: Bulgarian cucumber tossing
+
+Question 3.
+Your favorite food: Sauerkraut with spaghetti


### PR DESCRIPTION
Updated 'answers.txt' and added 'Lists/Students/0000001010011010/cities.txt' according to the assignment.
In 'answers.txt', updated the number of students who have edited the file to reflect the actual number of edits.
"grep -c ^--- answers.txt" yielded a count of 114, one of which was the template, but one student had omitted the line of dashes separating entries. Therefore the previous correct number of entries was 114 and the new number is now 114 + 1 = 115.